### PR TITLE
Fix bug for Import only mdlData

### DIFF
--- a/src/MDL.js
+++ b/src/MDL.js
@@ -66,7 +66,7 @@ class MDL {
       flags: this.getFlagStrings(),
       surfaceProp: this.surfaceProp,
       LODs: this.vertices.length,
-      verticeNumber: this.vertices[0].length,
+      verticeNumber: this.vertices.length ? this.vertices[0].length : 0,
       textures: this.textures,
       textureDirs: this.textureDirs
     }


### PR DESCRIPTION
`Fixed Error: UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'length' of undefined`

```js
        const mdl = new MDL();
        mdl.import({
            mdlData: this.model.data,
            // If we import all three files (data) we do not get any error
            // vtxData: fs.readFileSync(path.join(this.model.dir, `${this.model.name}.dx90.vtx`)),
            // vvdData: fs.readFileSync(path.join(this.model.dir, `${this.model.name}.vvd`)),
        });
        this.metadata = mdl.getMetadata() // error
```

Oh yep, I think we can fix that by: `verticeNumber: this.vertices[0]?.length,` but then we do not support `nodejs < 14.x.x`.